### PR TITLE
Add support for `allowDashes`

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,13 @@ var EMPTY = '';
  *   dashes.
  * @return {string} - Normalized `value`.
  */
-function normalize(value, allowApostrophes, allowDashes) {
+function normalize(value, options) {
     var result = (typeof value === 'string' ? value : toString(value))
         .toLowerCase();
+
+    var options = options || {};
+    var allowApostrophes = options.allowApostrophes || false;
+    var allowDashes = options.allowDashes || false;
 
     if (allowApostrophes && allowDashes) {
         return result;
@@ -59,6 +63,7 @@ function normalize(value, allowApostrophes, allowDashes) {
 
     return result.replace(ALL, EMPTY);
 }
+
 
 /*
  * Expose.

--- a/index.js
+++ b/index.js
@@ -40,9 +40,9 @@ function normalize(value, options) {
     var result = (typeof value === 'string' ? value : toString(value))
         .toLowerCase();
 
-    var options = options || {};
-    var allowApostrophes = options.allowApostrophes || false;
-    var allowDashes = options.allowDashes || false;
+    var settings = options || {};
+    var allowApostrophes = settings.allowApostrophes || false;
+    var allowDashes = settings.allowDashes || false;
 
     if (allowApostrophes && allowDashes) {
         return result;

--- a/index.js
+++ b/index.js
@@ -30,10 +30,8 @@ var EMPTY = '';
  * Normalize `value`.
  *
  * @param {string} value - Value to normalize.
- * @param {boolean} allowApostrophes - Do not strip
- *   apostrophes.
- * @param {boolean} allowDashes - Do not strip
- *   dashes.
+ * @param {Object?} options - Control stripping
+ *   apostrophes and dashes.
  * @return {string} - Normalized `value`.
  */
 function normalize(value, options) {
@@ -63,7 +61,6 @@ function normalize(value, options) {
 
     return result.replace(ALL, EMPTY);
 }
-
 
 /*
  * Expose.

--- a/index.js
+++ b/index.js
@@ -32,16 +32,29 @@ var EMPTY = '';
  * @param {string} value - Value to normalize.
  * @param {boolean} allowApostrophes - Do not strip
  *   apostrophes.
+ * @param {boolean} allowDashes - Do not strip
+ *   dashes.
  * @return {string} - Normalized `value`.
  */
-function normalize(value, allowApostrophes) {
+function normalize(value, allowApostrophes, allowDashes) {
     var result = (typeof value === 'string' ? value : toString(value))
         .toLowerCase();
+
+    if (allowApostrophes && allowDashes) {
+        return result;
+    }
 
     if (allowApostrophes) {
         return result
             .replace(APOSTROPHE, QUOTE)
             .replace(DASH, EMPTY);
+
+    }
+
+    if (allowDashes) {
+        return result
+            .replace(APOSTROPHE, EMPTY)
+            .replace(QUOTE, EMPTY);
     }
 
     return result.replace(ALL, EMPTY);

--- a/test.js
+++ b/test.js
@@ -219,13 +219,13 @@ test('Apostrophes', function (t) {
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', {allowApostrophes: false}),
+        normalize('Don\'t Block-Level', {'allowApostrophes': false}),
         'dont blocklevel',
         'should normalize dumb apostrophes (string) if false'
     );
 
     t.equal(
-        normalize('Don’t Block-Level', {allowApostrophes: false}),
+        normalize('Don’t Block-Level', {'allowApostrophes': false}),
         'dont blocklevel',
         'should normalize smart apostrophes (string) if false'
     );
@@ -259,7 +259,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: false}),
+        }, {'allowApostrophes': false}),
         'dont blocklevel',
         'should normalize dumb apostrophes (node) if false'
     );
@@ -293,7 +293,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: false}),
+        }, {'allowApostrophes': false}),
         'dont blocklevel',
         'should normalize smart apostrophes (node) if false'
     );
@@ -324,7 +324,7 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: false}),
+        ], {'allowApostrophes': false}),
         'dont blocklevel',
         'should normalize dumb apostrophes (multiple nodes) if false'
     );
@@ -355,19 +355,19 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: false}),
+        ], {'allowApostrophes': false}),
         'dont blocklevel',
         'should normalize smart apostrophes (multiple nodes) if false'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', {allowApostrophes: true}),
+        normalize('Don\'t Block-Level', {'allowApostrophes': true}),
         'don\'t blocklevel',
         'should not normalize dumb apostrophes (string) if true'
     );
 
     t.equal(
-        normalize('Don’t Block-Level', {allowApostrophes: true}),
+        normalize('Don’t Block-Level', {'allowApostrophes': true}),
         'don\'t blocklevel',
         'should normalize smart apostrophes (string) if true'
     );
@@ -401,7 +401,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: true}),
+        }, {'allowApostrophes': true}),
         'don\'t blocklevel',
         'should not normalize dumb apostrophes (node) if true'
     );
@@ -435,7 +435,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: true}),
+        }, {'allowApostrophes': true}),
         'don\'t blocklevel',
         'should normalize smart apostrophes (node) if true'
     );
@@ -466,7 +466,7 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: true}),
+        ], {'allowApostrophes': true}),
         'don\'t blocklevel',
         'should not normalize dumb apostrophes (multiple nodes) if true'
     );
@@ -497,7 +497,7 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: true}),
+        ], {'allowApostrophes': true}),
         'don\'t blocklevel',
         'should normalize smart apostrophes (multiple nodes) if true'
     );
@@ -578,13 +578,19 @@ test('Dashes', function (t) {
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', {allowApostrophes: false, allowDashes: false}),
+        normalize('Don\'t Block-Level', {
+            'allowApostrophes': false,
+            'allowDashes': false
+        }),
         'dont blocklevel',
         'should normalize dashes (string) if false'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', {allowApostrophes: true, allowDashes: false}), 
+        normalize('Don\'t Block-Level', {
+            'allowApostrophes': true,
+            'allowDashes': false
+        }),
         'don\'t blocklevel',
         'should normalize dashes (string) if false and apos true'
     );
@@ -618,7 +624,7 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: false, allowDashes: false}),
+        }, {'allowApostrophes': false, 'allowDashes': false}),
         'dont blocklevel',
         'should normalize dashes (node) if false'
     );
@@ -652,7 +658,7 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: true, allowDashes: false}),
+        }, {'allowApostrophes': true, 'allowDashes': false}),
         'don\'t blocklevel',
         'should normalize dashes (node) if false and apos true'
     );
@@ -683,7 +689,7 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: false, allowDashes: false}),
+        ], {'allowApostrophes': false, 'allowDashes': false}),
         'dont blocklevel',
         'should normalize dashes (multiple nodes) if false'
     );
@@ -714,19 +720,25 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: true, allowDashes: false}),
+        ], {'allowApostrophes': true, 'allowDashes': false}),
         'don\'t blocklevel',
         'should normalize dashes (multiple nodes) if false and apos true'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', {allowApostrophes: false, allowDashes: true}),
+        normalize('Don\'t Block-Level', {
+            'allowApostrophes': false,
+            'allowDashes': true
+        }),
         'dont block-level',
         'should not normalize dashes (string) if true'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', {allowApostrophes: true, allowDashes: true}),
+        normalize('Don\'t Block-Level', {
+            'allowApostrophes': true,
+            'allowDashes': true
+        }),
         'don\'t block-level',
         'should not normalize dashes (string) if true and apos true'
     );
@@ -760,7 +772,11 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: false, allowDashes: true}),
+        },
+        {
+            'allowApostrophes': false,
+            'allowDashes': true
+        }),
         'dont block-level',
         'should not normalize dashes (node) if true'
     );
@@ -794,7 +810,10 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {allowApostrophes: true, allowDashes: true}),
+        },
+        {'allowApostrophes': true,
+        'allowDashes': true
+        }),
         'don\'t block-level',
         'should not normalize dashes (node) if true and apos true'
     );
@@ -825,7 +844,7 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: false, allowDashes: true}),
+        ], {'allowApostrophes': false, 'allowDashes': true}),
         'dont block-level',
         'should not normalize dashes (multiple nodes) if true'
     );
@@ -856,7 +875,11 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {allowApostrophes: true, allowDashes: true}),
+        ],
+        {
+            'allowApostrophes': true,
+            'allowDashes': true
+        }),
         'don\'t block-level',
         'should not normalize dashes (multiple nodes) if true and apos true'
     );

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ var normalize = require('./');
  * Tests.
  */
 
-test('Basic', function (t) {
+test('Basic', function (t, options) {
     t.throws(
         function () {
             normalize(true);
@@ -32,7 +32,7 @@ test('Basic', function (t) {
     t.end();
 });
 
-test('Case', function (t) {
+test('Case', function (t, options) {
     t.equal(
         normalize('Dont'),
         'dont',
@@ -219,13 +219,13 @@ test('Apostrophes', function (t) {
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', false),
+        normalize('Don\'t Block-Level', {allowApostrophes: false}),
         'dont blocklevel',
         'should normalize dumb apostrophes (string) if false'
     );
 
     t.equal(
-        normalize('Don’t Block-Level', false),
+        normalize('Don’t Block-Level', {allowApostrophes: false}),
         'dont blocklevel',
         'should normalize smart apostrophes (string) if false'
     );
@@ -259,7 +259,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, false),
+        }, {allowApostrophes: false}),
         'dont blocklevel',
         'should normalize dumb apostrophes (node) if false'
     );
@@ -293,7 +293,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, false),
+        }, {allowApostrophes: false}),
         'dont blocklevel',
         'should normalize smart apostrophes (node) if false'
     );
@@ -324,7 +324,7 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], false),
+        ], {allowApostrophes: false}),
         'dont blocklevel',
         'should normalize dumb apostrophes (multiple nodes) if false'
     );
@@ -355,19 +355,19 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], false),
+        ], {allowApostrophes: false}),
         'dont blocklevel',
         'should normalize smart apostrophes (multiple nodes) if false'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', true),
+        normalize('Don\'t Block-Level', {allowApostrophes: true}),
         'don\'t blocklevel',
         'should not normalize dumb apostrophes (string) if true'
     );
 
     t.equal(
-        normalize('Don’t Block-Level', true),
+        normalize('Don’t Block-Level', {allowApostrophes: true}),
         'don\'t blocklevel',
         'should normalize smart apostrophes (string) if true'
     );
@@ -401,7 +401,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, true),
+        }, {allowApostrophes: true}),
         'don\'t blocklevel',
         'should not normalize dumb apostrophes (node) if true'
     );
@@ -435,7 +435,7 @@ test('Apostrophes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, true),
+        }, {allowApostrophes: true}),
         'don\'t blocklevel',
         'should normalize smart apostrophes (node) if true'
     );
@@ -466,7 +466,7 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], true),
+        ], {allowApostrophes: true}),
         'don\'t blocklevel',
         'should not normalize dumb apostrophes (multiple nodes) if true'
     );
@@ -497,7 +497,7 @@ test('Apostrophes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], true),
+        ], {allowApostrophes: true}),
         'don\'t blocklevel',
         'should normalize smart apostrophes (multiple nodes) if true'
     );
@@ -578,13 +578,13 @@ test('Dashes', function (t) {
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', false, false),
+        normalize('Don\'t Block-Level', {allowApostrophes: false, allowDashes: false}),
         'dont blocklevel',
         'should normalize dashes (string) if false'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', true, false),
+        normalize('Don\'t Block-Level', {allowApostrophes: true, allowDashes: false}), 
         'don\'t blocklevel',
         'should normalize dashes (string) if false and apos true'
     );
@@ -618,7 +618,7 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, false, false),
+        }, {allowApostrophes: false, allowDashes: false}),
         'dont blocklevel',
         'should normalize dashes (node) if false'
     );
@@ -652,7 +652,7 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, true, false),
+        }, {allowApostrophes: true, allowDashes: false}),
         'don\'t blocklevel',
         'should normalize dashes (node) if false and apos true'
     );
@@ -683,7 +683,7 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], false, false),
+        ], {allowApostrophes: false, allowDashes: false}),
         'dont blocklevel',
         'should normalize dashes (multiple nodes) if false'
     );
@@ -714,19 +714,19 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], true, false),
+        ], {allowApostrophes: true, allowDashes: false}),
         'don\'t blocklevel',
         'should normalize dashes (multiple nodes) if false and apos true'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', false, true),
+        normalize('Don\'t Block-Level', {allowApostrophes: false, allowDashes: true}),
         'dont block-level',
         'should not normalize dashes (string) if true'
     );
 
     t.equal(
-        normalize('Don\'t Block-Level', true, true),
+        normalize('Don\'t Block-Level', {allowApostrophes: true, allowDashes: true}),
         'don\'t block-level',
         'should not normalize dashes (string) if true and apos true'
     );
@@ -760,7 +760,7 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, false, true),
+        }, {allowApostrophes: false, allowDashes: true}),
         'dont block-level',
         'should not normalize dashes (node) if true'
     );
@@ -794,7 +794,7 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, true, true),
+        }, {allowApostrophes: true, allowDashes: true}),
         'don\'t block-level',
         'should not normalize dashes (node) if true and apos true'
     );
@@ -825,7 +825,7 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], false, true),
+        ], {allowApostrophes: false, allowDashes: true}),
         'dont block-level',
         'should not normalize dashes (multiple nodes) if true'
     );
@@ -856,7 +856,7 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], true, true),
+        ], {allowApostrophes: true, allowDashes: true}),
         'don\'t block-level',
         'should not normalize dashes (multiple nodes) if true and apos true'
     );

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('Case', function (t) {
     t.end();
 });
 
-test('Apostrophes', function (t, options) {
+test('Apostrophes', function (t) {
     t.equal(
         normalize('Don\'t Block-Level'),
         'dont blocklevel',
@@ -505,7 +505,7 @@ test('Apostrophes', function (t, options) {
     t.end();
 });
 
-test('Dashes', function (t, options) {
+test('Dashes', function (t) {
     t.equal(
         normalize('Don\'t Block-Level'),
         'dont blocklevel',

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ var normalize = require('./');
  * Tests.
  */
 
-test('Basic', function (t, options) {
+test('Basic', function (t) {
     t.throws(
         function () {
             normalize(true);
@@ -32,7 +32,7 @@ test('Basic', function (t, options) {
     t.end();
 });
 
-test('Case', function (t, options) {
+test('Case', function (t) {
     t.equal(
         normalize('Dont'),
         'dont',
@@ -75,7 +75,7 @@ test('Case', function (t, options) {
     t.end();
 });
 
-test('Apostrophes', function (t) {
+test('Apostrophes', function (t, options) {
     t.equal(
         normalize('Don\'t Block-Level'),
         'dont blocklevel',
@@ -505,7 +505,7 @@ test('Apostrophes', function (t) {
     t.end();
 });
 
-test('Dashes', function (t) {
+test('Dashes', function (t, options) {
     t.equal(
         normalize('Don\'t Block-Level'),
         'dont blocklevel',

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ var normalize = require('./');
  * Tests.
  */
 
-test('normalize(value, allowApostrophes)', function (t) {
+test('Basic', function (t) {
     t.throws(
         function () {
             normalize(true);
@@ -29,28 +29,14 @@ test('normalize(value, allowApostrophes)', function (t) {
         'should fail when given a boolean'
     );
 
+    t.end();
+});
+
+test('Case', function (t) {
     t.equal(
         normalize('Dont'),
         'dont',
         'should normalize case (string)'
-    );
-
-    t.equal(
-        normalize('Don\'t'),
-        'dont',
-        'should normalize dumb apostrophes (string)'
-    );
-
-    t.equal(
-        normalize('Don’t'),
-        'dont',
-        'should normalize smart apostrophes (string)'
-    );
-
-    t.equal(
-        normalize('Block-level'),
-        'blocklevel',
-        'should normalize dashes (string)'
     );
 
     t.equal(
@@ -65,72 +51,6 @@ test('normalize(value, allowApostrophes)', function (t) {
         }),
         'dont',
         'should normalize case (node)'
-    );
-
-    t.equal(
-        normalize({
-            'type': 'WordNode',
-            'children': [
-                {
-                    'type': 'TextNode',
-                    'value': 'Don'
-                },
-                {
-                    'type': 'PunctuationNode',
-                    'value': '\''
-                },
-                {
-                    'type': 'TextNode',
-                    'value': 't'
-                }
-            ]
-        }),
-        'dont',
-        'should normalize dumb apostrophes (node)'
-    );
-
-    t.equal(
-        normalize({
-            'type': 'WordNode',
-            'children': [
-                {
-                    'type': 'TextNode',
-                    'value': 'Don'
-                },
-                {
-                    'type': 'PunctuationNode',
-                    'value': '’'
-                },
-                {
-                    'type': 'TextNode',
-                    'value': 't'
-                }
-            ]
-        }),
-        'dont',
-        'should normalize smart apostrophes (node)'
-    );
-
-    t.equal(
-        normalize({
-            'type': 'WordNode',
-            'children': [
-                {
-                    'type': 'TextNode',
-                    'value': 'Block'
-                },
-                {
-                    'type': 'PunctuationNode',
-                    'value': '-'
-                },
-                {
-                    'type': 'TextNode',
-                    'value': 'level'
-                }
-            ]
-        }),
-        'blocklevel',
-        'should normalize dashes (node)'
     );
 
     t.equal(
@@ -149,14 +69,798 @@ test('normalize(value, allowApostrophes)', function (t) {
             }
         ]),
         'blocklevel',
-        'should normalize multiple nodes'
-    );
-
-    t.equal(
-        normalize('he’ll', true),
-        'he\'ll',
-        'should normalize apostrophes when specified'
+        'should normalize case (multiple nodes)'
     );
 
     t.end();
 });
+
+test('Apostrophes', function (t) {
+    t.equal(
+        normalize('Don\'t Block-Level'),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (string)'
+    );
+
+    t.equal(
+        normalize('Don’t Block-Level'),
+        'dont blocklevel',
+        'should normalize smart apostrophes (string)'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (node)'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '’'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }),
+        'dont blocklevel',
+        'should normalize smart apostrophes (node)'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ]),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (multiple nodes)'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '’'
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ]),
+        'dont blocklevel',
+        'should normalize smart apostrophes (multiple nodes)'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', false),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (string) if false'
+    );
+
+    t.equal(
+        normalize('Don’t Block-Level', false),
+        'dont blocklevel',
+        'should normalize smart apostrophes (string) if false'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (node) if false'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '’'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false),
+        'dont blocklevel',
+        'should normalize smart apostrophes (node) if false'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false),
+        'dont blocklevel',
+        'should normalize dumb apostrophes (multiple nodes) if false'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '’'
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false),
+        'dont blocklevel',
+        'should normalize smart apostrophes (multiple nodes) if false'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', true),
+        'don\'t blocklevel',
+        'should not normalize dumb apostrophes (string) if true'
+    );
+
+    t.equal(
+        normalize('Don’t Block-Level', true),
+        'don\'t blocklevel',
+        'should normalize smart apostrophes (string) if true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true),
+        'don\'t blocklevel',
+        'should not normalize dumb apostrophes (node) if true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '’'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true),
+        'don\'t blocklevel',
+        'should normalize smart apostrophes (node) if true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true),
+        'don\'t blocklevel',
+        'should not normalize dumb apostrophes (multiple nodes) if true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '’'
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true),
+        'don\'t blocklevel',
+        'should normalize smart apostrophes (multiple nodes) if true'
+    );
+
+    t.end();
+});
+
+test('Dashes', function (t) {
+    t.equal(
+        normalize('Don\'t Block-Level'),
+        'dont blocklevel',
+        'should normalize dashes (string)'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }),
+        'dont blocklevel',
+        'should normalize dashes (node)'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ]),
+        'dont blocklevel',
+        'should normalize dashes (multiple nodes)'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', false, false),
+        'dont blocklevel',
+        'should normalize dashes (string) if false'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', true, false),
+        'don\'t blocklevel',
+        'should normalize dashes (string) if false and apos true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false, false),
+        'dont blocklevel',
+        'should normalize dashes (node) if false'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true, false),
+        'don\'t blocklevel',
+        'should normalize dashes (node) if false and apos true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false, false),
+        'dont blocklevel',
+        'should normalize dashes (multiple nodes) if false'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true, false),
+        'don\'t blocklevel',
+        'should normalize dashes (multiple nodes) if false and apos true'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', false, true),
+        'dont block-level',
+        'should not normalize dashes (string) if true'
+    );
+
+    t.equal(
+        normalize('Don\'t Block-Level', true, true),
+        'don\'t block-level',
+        'should not normalize dashes (string) if true and apos true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, false, true),
+        'dont block-level',
+        'should not normalize dashes (node) if true'
+    );
+
+    t.equal(
+        normalize({
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'Don'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '\''
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 't '
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Block'
+                },
+                {
+                    'type': 'PunctuationNode',
+                    'value': '-'
+                },
+                {
+                    'type': 'TextNode',
+                    'value': 'Level'
+                }
+            ]
+        }, true, true),
+        'don\'t block-level',
+        'should not normalize dashes (node) if true and apos true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], false, true),
+        'dont block-level',
+        'should not normalize dashes (multiple nodes) if true'
+    );
+
+    t.equal(
+        normalize([
+            {
+                'type': 'TextNode',
+                'value': 'Don'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '\''
+            },
+            {
+                'type': 'TextNode',
+                'value': 't '
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Block'
+            },
+            {
+                'type': 'PunctuationNode',
+                'value': '-'
+            },
+            {
+                'type': 'TextNode',
+                'value': 'Level'
+            }
+        ], true, true),
+        'don\'t block-level',
+        'should not normalize dashes (multiple nodes) if true and apos true'
+    );
+
+    t.end();
+});
+

--- a/test.js
+++ b/test.js
@@ -624,7 +624,11 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {'allowApostrophes': false, 'allowDashes': false}),
+        },
+        {
+            'allowApostrophes': false,
+            'allowDashes': false
+        }),
         'dont blocklevel',
         'should normalize dashes (node) if false'
     );
@@ -658,7 +662,11 @@ test('Dashes', function (t) {
                     'value': 'Level'
                 }
             ]
-        }, {'allowApostrophes': true, 'allowDashes': false}),
+        },
+        {
+            'allowApostrophes': true,
+            'allowDashes': false
+        }),
         'don\'t blocklevel',
         'should normalize dashes (node) if false and apos true'
     );
@@ -689,7 +697,11 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {'allowApostrophes': false, 'allowDashes': false}),
+        ],
+        {
+            'allowApostrophes': false,
+            'allowDashes': false
+        }),
         'dont blocklevel',
         'should normalize dashes (multiple nodes) if false'
     );
@@ -720,7 +732,11 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {'allowApostrophes': true, 'allowDashes': false}),
+        ],
+        {
+            'allowApostrophes': true,
+            'allowDashes': false
+        }),
         'don\'t blocklevel',
         'should normalize dashes (multiple nodes) if false and apos true'
     );
@@ -811,8 +827,9 @@ test('Dashes', function (t) {
                 }
             ]
         },
-        {'allowApostrophes': true,
-        'allowDashes': true
+        {
+            'allowApostrophes': true,
+            'allowDashes': true
         }),
         'don\'t block-level',
         'should not normalize dashes (node) if true and apos true'
@@ -844,7 +861,11 @@ test('Dashes', function (t) {
                 'type': 'TextNode',
                 'value': 'Level'
             }
-        ], {'allowApostrophes': false, 'allowDashes': true}),
+        ],
+        {
+            'allowApostrophes': false,
+            'allowDashes': true
+        }),
         'dont block-level',
         'should not normalize dashes (multiple nodes) if true'
     );


### PR DESCRIPTION
## Problem

We want `retext-shopify`, which is based on `retext-simplify`, not to strip out hyphens when performing matches. For instance, we want to be able to tell people that `drop-down menu` is the preferred spelling, rather than `drop down menu` or `dropdown menu`.
## Solution

We added a control for `allowDashes` similar to `allowApostrophes`. If `allowDashes` is true, apostrophes are stripped out and hyphens are left alone. `allowApostrophes` operates the same as before, stripping out hyphens, converting apostrophes to straight quotes, and leaving straight quotes alone. If both `allowDashes` and `allowApostrophes` are true, neither type of punctuation is stripped out. 
## Notes

Dave notes that the test coverage may be excessive, but since he used these tests to resolve the problem I was having, he left them in there.

We've made related changes to `nlcst-search` --- am creating a PR now. @admhlt
